### PR TITLE
chg: dev: Modifying library function names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 sflowtool Communication Library for Topology
 ============================================
 
-A sflowtool Communication Library for the Topology Network Framework
+An sflowtool Communication Library for the Topology Network Framework
 
 
 Documentation

--- a/lib/topology_lib_sflowtool/library.py
+++ b/lib/topology_lib_sflowtool/library.py
@@ -41,7 +41,7 @@ class SflowtoolState(object):
 
 
 @stateprovider(SflowtoolState)
-def sflowtool_start(enode, state, mode, port=6343):
+def start(enode, state, mode, port=6343):
     """
     Start sflowtool
 
@@ -67,7 +67,7 @@ def sflowtool_start(enode, state, mode, port=6343):
 
 
 @stateprovider(SflowtoolState)
-def sflowtool_stop(enode, state):
+def stop(enode, state):
     """
     Stop sflowtool
 
@@ -87,6 +87,6 @@ def sflowtool_stop(enode, state):
 
 
 __all__ = [
-    'sflowtool_start',
-    'sflowtool_stop'
+    'start',
+    'stop'
 ]


### PR DESCRIPTION
Changed sflowtool_start() to start()
Changed sflowtool_stop() to stop()

Signed-off-by: Vasanth Viswanathan vasanth.viswanathan@hpe.com
